### PR TITLE
[docs] Kitchen upgrade - version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-#Hubben 2.1
+#Hubben 2.2
 This repository describes the changes to the students premises at the Information Technology Student Division at Chalmers


### PR DESCRIPTION
When the kitchen upgrade is finished we should bump Hubbens version from 2.1 to 2.2 

I have updated the required docs in this PR and the changes both passes all tests and doesn't change test coverage.

As the spec isn't finished there may be some breaking changes. For example ArmITs piggy bank breaking to pay for the upgrade. 